### PR TITLE
Phase 7: Create IGameService in Application layer

### DIFF
--- a/ChessLib/Pieces/PieceColor.cs
+++ b/ChessLib/Pieces/PieceColor.cs
@@ -1,8 +1,5 @@
 ﻿namespace ChessLib.Pieces
 {
-    /// <summary>
-    /// Цвет фигур
-    /// </summary>
     public enum PieceColor
     {
         White,

--- a/WPFChess/Services/GameService.cs
+++ b/WPFChess/Services/GameService.cs
@@ -1,0 +1,103 @@
+using ChessLib;
+using ChessLib.Common;
+using ChessLib.Pieces;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ChessWPF.Services
+{
+    public class GameService : IGameService
+    {
+        private readonly IGameEngine _gameEngine;
+
+        public GameService(IGameEngine gameEngine)
+        {
+            _gameEngine = gameEngine ?? throw new ArgumentNullException(nameof(gameEngine));
+            LogInfo("GameService initialized");
+        }
+
+        public GameService() : this(new GameEngine())
+        {
+        }
+
+        public MoveResult MakeMove(ChessLib.Common.Position from, ChessLib.Common.Position to)
+        {
+            LogInfo($"MakeMove: {from} -> {to}");
+            var result = _gameEngine.MakeMove(from, to);
+            
+            if (result.IsValid)
+            {
+                LogInfo($"Move successful: {result.MoveType}, Check: {result.IsCheck}, Checkmate: {result.IsCheckmate}");
+            }
+            else
+            {
+                LogWarning($"Move failed: {result.ErrorMessage ?? "Unknown error"}");
+            }
+            
+            return result;
+        }
+
+        public IGameState GetState()
+        {
+            var state = _gameEngine.GetState();
+            LogDebug($"GetState: CurrentPlayer={state.CurrentPlayerColor}, Check={state.IsCheck}, Checkmate={state.IsCheckmate}, GameOver={state.IsGameOver}");
+            return state;
+        }
+
+        public IReadOnlyList<ChessLib.Common.Position> GetValidMoves(ChessLib.Common.Position position)
+        {
+            var moves = _gameEngine.GetValidMoves(position);
+            LogDebug($"GetValidMoves({position}): Found {moves.Count} valid moves");
+            return moves;
+        }
+
+        public string GetFen()
+        {
+            var fen = _gameEngine.GetFen();
+            LogDebug($"GetFen: {fen}");
+            return fen;
+        }
+
+        public string GetMoveHistory()
+        {
+            var history = _gameEngine.GetMoveHistory();
+            LogDebug($"GetMoveHistory: {history?.Length ?? 0} characters");
+            return history;
+        }
+
+        public void StartNewGame()
+        {
+            LogInfo("StartNewGame: Starting a new game");
+            _gameEngine.StartNewGame();
+            LogInfo("StartNewGame: New game started successfully");
+        }
+
+        public void EndGameByTime(PieceColor losingColor)
+        {
+            LogInfo($"EndGameByTime: Game ended, losing color: {losingColor}");
+            _gameEngine.EndGameByTime(losingColor);
+        }
+
+        #region Logging
+
+        private void LogInfo(string message)
+        {
+            Debug.WriteLine($"[GameService] [INFO] {DateTime.Now:HH:mm:ss.fff} - {message}");
+        }
+
+        private void LogWarning(string message)
+        {
+            Debug.WriteLine($"[GameService] [WARN] {DateTime.Now:HH:mm:ss.fff} - {message}");
+        }
+
+        private void LogDebug(string message)
+        {
+#if DEBUG
+            Debug.WriteLine($"[GameService] [DEBUG] {DateTime.Now:HH:mm:ss.fff} - {message}");
+#endif
+        }
+
+        #endregion
+    }
+}

--- a/WPFChess/Services/IGameService.cs
+++ b/WPFChess/Services/IGameService.cs
@@ -1,0 +1,17 @@
+using ChessLib;
+using ChessLib.Common;
+using System.Collections.Generic;
+
+namespace ChessWPF.Services
+{
+    public interface IGameService
+    {
+        MoveResult MakeMove(ChessLib.Common.Position from, ChessLib.Common.Position to);
+        IGameState GetState();
+        IReadOnlyList<ChessLib.Common.Position> GetValidMoves(ChessLib.Common.Position position);
+        string GetFen();
+        string GetMoveHistory();
+        void StartNewGame();
+        void EndGameByTime(ChessLib.Pieces.PieceColor losingColor);
+    }
+}


### PR DESCRIPTION
# Phase 7: Create IGameService in Application Layer

## Description

Phase 7 of refactoring: creating `IGameService` abstraction in the Application layer to isolate the WPF application from ChessLib library implementation details.

## Goal

Create `IGameService` interface and its `GameService` implementation that:
- Provides a single entry point for the WPF application
- Uses `IGameEngine` from ChessLib library
- Returns `IGameState` directly without transformations
- Includes logging for all operations for debugging and monitoring

## Architectural Changes

### Before (Current Architecture)

```
WPF ViewModels
    ↓
ChessGameService (direct dependency on Game)
    ↓
Game (public properties, encapsulation violation)
```

### After (New Architecture)

```
WPF ViewModels
    ↓
IGameService (interface)
    ↓
GameService (implementation with logging)
    ↓
IGameEngine (interface from library)
    ↓
GameEngine (encapsulated implementation)
```

## Architecture Diagram

```mermaid
graph TB
    subgraph Before["Before (Current Architecture)"]
        direction TB
        WPF_Before["WPF ViewModels"]
        CGS["ChessGameService<br/>Direct dependency"]
        Game_Before["Game<br/>Public properties"]
        
        WPF_Before -->|"direct dependency"| CGS
        CGS -->|"direct dependency"| Game_Before
    end
    
    subgraph After["After (New Architecture)"]
        direction TB
        WPF_After["WPF ViewModels"]
        IGS["IGameService<br/>Interface"]
        GS["GameService<br/>Implementation + logging"]
        IGE["IGameEngine<br/>Library interface"]
        GE["GameEngine<br/>Encapsulated implementation"]
        
        WPF_After -->|"via interface"| IGS
        IGS -.->|"implements"| GS
        GS -->|"via interface"| IGE
        IGE -.->|"implements"| GE
    end
    
    style CGS fill:#ff6b6b,stroke:#c92a2a,stroke-width:2px,color:#ffffff
    style Game_Before fill:#ff6b6b,stroke:#c92a2a,stroke-width:2px,color:#ffffff
    style IGS fill:#2f9e44,stroke:#1e7e34,stroke-width:2px,color:#ffffff
    style GS fill:#2f9e44,stroke:#1e7e34,stroke-width:2px,color:#ffffff
    style IGE fill:#2f9e44,stroke:#1e7e34,stroke-width:2px,color:#ffffff
    style GE fill:#2f9e44,stroke:#1e7e34,stroke-width:2px,color:#ffffff
```

## Sequence Diagram

```mermaid
sequenceDiagram
    participant WPF as WPF ViewModel
    participant IGS as IGameService
    participant GS as GameService
    participant IGE as IGameEngine
    participant GE as GameEngine
    
    Note over WPF,GE: New architecture with abstractions
    
    WPF->>+IGS: MakeMove(from, to)
    activate IGS
    IGS->>+GS: MakeMove(from, to)
    activate GS
    Note right of GS: Logging: "MakeMove: (x,y) -> (x,y)"
    GS->>+IGE: MakeMove(from, to)
    activate IGE
    IGE->>+GE: MakeMove(from, to)
    activate GE
    GE-->>-IGE: MoveResult
    deactivate GE
    IGE-->>-GS: MoveResult
    deactivate IGE
    Note right of GS: Logging result<br/>(success/error, check/checkmate)
    GS-->>-IGS: MoveResult
    deactivate GS
    IGS-->>-WPF: MoveResult
    deactivate IGS
    
    WPF->>+IGS: GetState()
    IGS->>+GS: GetState()
    Note right of GS: Logging state<br/>(DEBUG mode)
    GS->>+IGE: GetState()
    IGE->>+GE: GetState()
    GE-->>-IGE: IGameState
    IGE-->>-GS: IGameState
    GS-->>-IGS: IGameState
    IGS-->>-WPF: IGameState
```

## Benefits

1. **WPF Isolation from Library**
   - WPF uses only `IGameService` interface
   - Does not know about `GameEngine` or `Game` internals

2. **Operation Logging**
   - All game operations are logged
   - Simplifies debugging and monitoring
   - Different log levels (Info, Warning, Debug)

3. **Flexibility**
   - Easy to replace `GameService` implementation
   - Can add additional logic (validation, caching)

4. **Migration Preparation**
   - Ready for use in WPF ViewModels (Phase 8)
   - Will replace `ChessGameService` and `BoardStateSnapshot`

## Next Steps (Phase 8)

- Migrate WPF ViewModels to use `IGameService`
- Replace `ChessGameService` with `GameService`
- Remove `BoardStateSnapshot` (use `IGameState` directly)
- Update DI container

## Usage Example

```csharp
// In DI container
services.AddSingleton<IGameService, GameService>();

// In ViewModel
public class GameViewModel
{
    private readonly IGameService _gameService;
    
    public GameViewModel(IGameService gameService)
    {
        _gameService = gameService;
    }
    
    public void MakeMove(Position from, Position to)
    {
        var result = _gameService.MakeMove(from, to);
        if (result.IsValid)
        {
            var state = _gameService.GetState();
            UpdateView(state);
        }
    }
}
```

## Related Documents

- [ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md) - full refactoring plan